### PR TITLE
Add support for simple markdown tables in argument help text

### DIFF
--- a/argparse_formatter/flexi_formatter.py
+++ b/argparse_formatter/flexi_formatter.py
@@ -41,8 +41,9 @@ class FlexiHelpFormatter(RawTextHelpFormatter):
         for line in text.splitlines():
             (indent, sub_indent) = self._indents(line)
             is_text = _re.search(r"[^\s]", line) is not None
+            is_table = _re.search(r"^\s*\|", line) is not None
 
-            if is_text and indent == sub_indent == last_sub_indent:
+            if is_text and (not is_table) and (indent == sub_indent == last_sub_indent):
                 paragraphs[-1] += " " + line
             else:
                 paragraphs.append(line)
@@ -64,7 +65,9 @@ class FlexiHelpFormatter(RawTextHelpFormatter):
 
             (indent, sub_indent) = self._indents(paragraph)
 
-            paragraph = self._whitespace_matcher.sub(" ", paragraph).strip()
+            is_table = paragraph and (_re.search(r"^\s*\|", paragraph) is not None)
+            if not is_table:
+                paragraph = self._whitespace_matcher.sub(" ", paragraph).strip()
             new_paragraphs = textwrap.wrap(
                 text=paragraph,
                 width=width,

--- a/flexidemo.py
+++ b/flexidemo.py
@@ -32,11 +32,20 @@ def argparse_demo(formatter):
     parser.add_argument(
         "--arg",
         help="""
-            This same feature would be useful for arguments that would benefit
-            from more explanation.
+            This same feature would be useful for arguments that would
+            benefit from
+            more explanation.
 
               1. It looks nicer
               2. It is easier to read, even if some of the bullets get to be a little long.
+              3. Also, there is a table:
+                 | Feature      | ParagraphFormatter | FlexiFormatter |
+                 | :---         | :---:              | :---:          |
+                 | Outputs text |        Yes         |       Yes      |
+                 | Bullets?     |        Yes         |       Yes      |
+                 | Tables       |        No          |       Yes      |
+              4. Bullets can follow tables.
+
         """,  # noqa
     )
 


### PR DESCRIPTION
Now tables in argument help text are left alone:

```
*************************                                                                                             
Using the Flexi formatter                                                                                             
*************************                                  
                                                                                                                      
usage: flexidemo.py [-h] [--arg ARG]             
                                                           
optional arguments:                                                                                                   
  -h, --help  show this help message and exit                                                                         
  --arg ARG   This same feature would be useful for arguments that would benefit from more explanation.               
                                                                                                                      
                1. It looks nicer                                                                                     
                2. It is easier to read, even if some of the bullets get to be a little long.                         
                3. Also, there is a table:                                                                            
                        | Feature      | ParagraphFormatter | FlexiFormatter |                               
                        | :---         | :---:              | :---:          |                                        
                        | Outputs text |        Yes         |       Yes      |                                        
                        | Bullets?     |        Yes         |       Yes      |                                        
                        | Tables       |        No          |       Yes      |                                        
                4. Bullets can follow tables.                                                                         
                                                                                                                      
This is a multi-paragraph epilog. It is presenting data that would benefit by being visually broken up into pieces.
                                                                                                                      
It sure would be nice if it was represented that way.      
                                                           
  1. This is a pretty long line, in a bullet list - getting longer and longer and longer
  2. this isn't                                                                                                       
```